### PR TITLE
Use https for `sdkjs-plugins` submodule, instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/ONLYOFFICE/dictionaries.git
 [submodule "sdkjs-plugins"]
 	path = sdkjs-plugins
-	url = git@github.com:ONLYOFFICE/sdkjs-plugins.git
+	url = https://github.com/ONLYOFFICE/sdkjs-plugins.git


### PR DESCRIPTION
Allow anonymous git clone

Without it `git clone --recursive https://github.com/ONLYOFFICE/DocumentServer.git` cause
```
Cloning into 'sdkjs-plugins'...
Warning: Permanently added the RSA host key for IP address '192.30.253.112' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:ONLYOFFICE/sdkjs-plugins.git' into submodule path 'sdkjs-plugins' failed
```