### PR TITLE
Spellcheck travis task will fail

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -409,7 +409,6 @@ WinXp
 wmf
 WrapText
 xfIndexNumber
-xls
 XLS
 XlsFormatReader
 xlsx

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -409,6 +409,7 @@ WinXp
 wmf
 WrapText
 xfIndexNumber
+xls
 XLS
 XlsFormatReader
 xlsx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ jobs:
       - npm install -g markdownlint-cli
       - markdownlint CHANGELOG.md
     - stage: spellcheck
-      script: cat CHANGELOG.md | aspell --lang=en --encoding=utf-8 --personal=./.aspell.en.pws list
+      script: if [[ $(cat CHANGELOG.md | aspell --lang=en --encoding=utf-8 --personal=./.aspell.en.pws list | wc -l) -ne 0 ]]; then exit 1 ; fi


### PR DESCRIPTION
Before it just output incorrect words, but task
was marked as green.